### PR TITLE
wrap for json release 3.2.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,6 @@
+project('json', 'cpp', version : '3.2.0', license : 'MIT',
+        default_options : ['cpp_std=c++11'])
+
+inc = include_directories('single_include')
+
+json_dep = declare_dependency(include_directories:inc)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = json-3.2.0
+
+source_url = https://github.com/nlohmann/json/archive/v3.2.0/json-3.2.0.tar.gz
+source_filename = json-3.2.0.tar.gz
+source_hash = 2de558ff3b3b32eebfb51cf2ceb835a0fa5170e6b8712b02be9c2c07fcfe52a1


### PR DESCRIPTION
Note that the include path changed with upstream release 3; now use:

#include <nlohmann/json.hpp>